### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/resources/languages/expanded/en_us.json
+++ b/resources/languages/expanded/en_us.json
@@ -2358,7 +2358,7 @@
     "advancements": {
       "name": "advancements",
       "type": "ChatInput",
-      "long_description": "Look up your and other member's unlocked/completed recipes/advancements. You can find a list of all advancement (ids) [here](https://minecraft.fandom.com/wiki/Advancement#List_of_advancements).",
+      "long_description": "Look up your and other member's unlocked/completed recipes/advancements. You can find a list of all advancement (ids) [here](https://minecraft.wiki/w/Advancement#List_of_advancements).",
       "description": "Look up your and other member's minecraft advancements.",
       "options": [
         {
@@ -2399,7 +2399,7 @@
     "stats": {
       "name": "stats",
       "type": "ChatInput",
-      "long_description": "Look at your and other member's minecraft server stats.\nAll Categories (ids) can be found [here](https://minecraft.fandom.com/wiki/Statistics#Statistic_types_and_names)!\nAll stats of the `custom` category can be found [here](https://minecraft.fandom.com/wiki/Statistics#Statistic_types_and_names).",
+      "long_description": "Look at your and other member's minecraft server stats.\nAll Categories (ids) can be found [here](https://minecraft.wiki/w/Statistics#Statistic_types_and_names)!\nAll stats of the `custom` category can be found [here](https://minecraft.wiki/w/Statistics#Statistic_types_and_names).",
       "description": "Look at your and other member's minecraft server stats.",
       "options": [
         {
@@ -2806,7 +2806,7 @@
     "message": {
       "name": "message",
       "type": "ChatInput",
-      "long_description": "Send private chat messages to members on the server. Color codes can be found [here](https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes).",
+      "long_description": "Send private chat messages to members on the server. Color codes can be found [here](https://minecraft.wiki/w/Formatting_codes#Color_codes).",
       "description": "Send private chat messages to members on the server.",
       "options": [
         {

--- a/resources/languages/flat/en_us.json
+++ b/resources/languages/flat/en_us.json
@@ -1202,7 +1202,7 @@
 
   "data.advancements.name": "advancements",
   "data.advancements.type": "ChatInput",
-  "data.advancements.long_description": "Look up your and other member's unlocked/completed recipes/advancements. You can find a list of all advancement (ids) [here](https://minecraft.fandom.com/wiki/Advancement#List_of_advancements).",
+  "data.advancements.long_description": "Look up your and other member's unlocked/completed recipes/advancements. You can find a list of all advancement (ids) [here](https://minecraft.wiki/w/Advancement#List_of_advancements).",
   "data.advancements.description": "Look up your and other member's minecraft advancements.",
 
   "data.advancements.options.0.type": "String",
@@ -1237,7 +1237,7 @@
 
   "data.stats.name": "stats",
   "data.stats.type": "ChatInput",
-  "data.stats.long_description": "Look at your and other member's minecraft server stats.\nAll Categories (ids) can be found [here](https://minecraft.fandom.com/wiki/Statistics#Statistic_types_and_names)!\nAll stats of the `custom` category can be found [here](https://minecraft.fandom.com/wiki/Statistics#Statistic_types_and_names).",
+  "data.stats.long_description": "Look at your and other member's minecraft server stats.\nAll Categories (ids) can be found [here](https://minecraft.wiki/w/Statistics#Statistic_types_and_names)!\nAll stats of the `custom` category can be found [here](https://minecraft.wiki/w/Statistics#Statistic_types_and_names).",
   "data.stats.description": "Look at your and other member's minecraft server stats.",
 
   "data.stats.options.0.type": "Subcommand",
@@ -1547,7 +1547,7 @@
 
   "data.message.name": "message",
   "data.message.type": "ChatInput",
-  "data.message.long_description": "Send private chat messages to members on the server. Color codes can be found [here](https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes).",
+  "data.message.long_description": "Send private chat messages to members on the server. Color codes can be found [here](https://minecraft.wiki/w/Formatting_codes#Color_codes).",
   "data.message.description": "Send private chat messages to members on the server.",
 
   "data.message.options.0.type": "String",


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.